### PR TITLE
feat: add support for discussion posts with dynamic routing

### DIFF
--- a/src/app/_client-utils/getPostDetailsUrl.ts
+++ b/src/app/_client-utils/getPostDetailsUrl.ts
@@ -1,0 +1,15 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { EProposalType } from '@/_shared/types';
+
+export const getPostDetailsUrl = (proposalType: EProposalType, proposalId: number) => {
+	// eslint-disable-next-line sonarjs/no-small-switch
+	switch (proposalType) {
+		case EProposalType.DISCUSSION:
+			return `/post/${proposalId}`;
+		default:
+			return `/referenda/${proposalId}`;
+	}
+};

--- a/src/app/_shared-components/ListingComponent/ListingCard/ListingCard.tsx
+++ b/src/app/_shared-components/ListingComponent/ListingCard/ListingCard.tsx
@@ -27,6 +27,7 @@ import { useTheme } from 'next-themes';
 import DOTIcon from '@assets/icons/dot.png';
 import { redirectFromServer } from '@/app/_client-utils/redirectFromServer';
 import Link from 'next/link';
+import { getPostDetailsUrl } from '@/app/_client-utils/getPostDetailsUrl';
 import styles from './ListingCard.module.scss';
 import VotingBar from '../VotingBar/VotingBar';
 
@@ -65,7 +66,7 @@ function ListingCard({
 
 	const groupedByAsset = groupBeneficiariesByAsset(beneficiaries, network);
 
-	const redirectUrl = [EProposalType.DISCUSSION].includes(proposalType) ? `/post/${index}` : `/referenda/${index}`;
+	const redirectUrl = getPostDetailsUrl(proposalType, index);
 	return (
 		<Link
 			href={redirectUrl}

--- a/src/app/_shared-components/PostDetails/PostDetails.tsx
+++ b/src/app/_shared-components/PostDetails/PostDetails.tsx
@@ -8,6 +8,7 @@ import { EPostDetailsTab, EProposalType, IPost, IPostListing } from '@/_shared/t
 import { cn } from '@/lib/utils';
 import { useState } from 'react';
 import { OutputData } from '@editorjs/editorjs';
+import { ValidatorService } from '@/_shared/_services/validator_service';
 import PostHeader from './PostHeader/PostHeader';
 import PostComments from '../PostComments/PostComments';
 import classes from './PostDetails.module.scss';
@@ -26,7 +27,7 @@ function PostDetails({ index, isModalOpen, postData }: { index: string; isModalO
 		setPost((prev) => ({ ...prev, title, content }));
 	};
 
-	const isOffchainPost = [EProposalType.DISCUSSION].includes(post.proposalType);
+	const isOffchainPost = ValidatorService.isValidOffChainProposalType(post.proposalType);
 
 	return (
 		<Tabs defaultValue={EPostDetailsTab.DESCRIPTION}>

--- a/src/app/_shared-components/PostDetails/PostHeader/PostHeader.tsx
+++ b/src/app/_shared-components/PostDetails/PostHeader/PostHeader.tsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { TabsList, TabsTrigger } from '@ui/Tabs';
 import { Separator } from '@ui/Separator';
-import { EAssets, EPostDetailsTab, EProposalType, IPostListing } from '@/_shared/types';
+import { EAssets, EPostDetailsTab, IPostListing } from '@/_shared/types';
 import { getCurrentNetwork } from '@/_shared/_utils/getCurrentNetwork';
 import { formatBnBalance } from '@/app/_client-utils/formatBnBalance';
 import Image from 'next/image';
@@ -19,6 +19,7 @@ import { getTimeRemaining } from '@/app/_client-utils/getTimeRemaining';
 import { calculateDecisionProgress } from '@/app/_client-utils/calculateDecisionProgress';
 
 import { useTranslations } from 'next-intl';
+import { ValidatorService } from '@/_shared/_services/validator_service';
 import classes from './PostHeader.module.scss';
 import Address from '../../Profile/Address/Address';
 import CreatedAtTime from '../../CreatedAtTime/CreatedAtTime';
@@ -48,7 +49,7 @@ function PostHeader({ postData, isModalOpen }: { postData: IPostListing; isModal
 	const timeRemaining = postData.onChainInfo?.decisionPeriodEndsAt ? getTimeRemaining(postData.onChainInfo?.decisionPeriodEndsAt) : null;
 	const formattedTime = timeRemaining ? `Deciding ends in ${timeRemaining.days}d : ${timeRemaining.hours}hrs : ${timeRemaining.minutes}mins` : 'Decision period has ended.';
 
-	const isOffchainPost = [EProposalType.DISCUSSION].includes(postData.proposalType);
+	const isOffchainPost = ValidatorService.isValidOffChainProposalType(postData.proposalType);
 
 	return (
 		<div>

--- a/src/app/post/[index]/page.tsx
+++ b/src/app/post/[index]/page.tsx
@@ -1,8 +1,10 @@
 // Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
 // This software may be modified and distributed under the terms
 // of the Apache-2.0 license. See the LICENSE file for details.
+import { ERROR_CODES, ERROR_MESSAGES } from '@/_shared/_constants/errorLiterals';
 import { EProposalType } from '@/_shared/types';
 import { NextApiClientService } from '@/app/_client-services/next_api_client_service';
+import { ClientError } from '@/app/_client-utils/clientError';
 import PostDetails from '@/app/_shared-components/PostDetails/PostDetails';
 import React from 'react';
 
@@ -10,7 +12,7 @@ async function DiscussionPost({ params }: { params: Promise<{ index: string }> }
 	const { index } = await params;
 	const { data, error } = await NextApiClientService.fetchProposalDetailsApi(EProposalType.DISCUSSION, index);
 
-	if (error || !data) return <div className='text-center text-text_primary'>{error?.message}</div>;
+	if (error || !data) throw new ClientError(ERROR_CODES.CLIENT_ERROR, error?.message || ERROR_MESSAGES[ERROR_CODES.CLIENT_ERROR]);
 
 	return (
 		<div className='h-full w-full bg-page_background'>


### PR DESCRIPTION
- Implement new `/post/[index]` page for discussion posts
- Update ListingCard to handle different proposal type redirects
- Modify PostDetails and PostHeader to conditionally render components for off-chain posts
- Add type-safe routing based on EProposalType