### PR TITLE
feat: Add network-specific tag metadata in Firestore post creation

### DIFF
--- a/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
+++ b/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
@@ -291,6 +291,7 @@ export class FirestoreService extends FirestoreRefs {
 		return {
 			...postData,
 			content: formattedContent,
+			tags: postData.tags?.map((tag: string) => ({ value: tag, lastUsedAt: postData.createdAt?.toDate(), network })) || [],
 			htmlContent,
 			markdownContent,
 			dataSource: EDataSource.POLKASSEMBLY,


### PR DESCRIPTION
- Enhance post data with network-specific tag information
- Include lastUsedAt timestamp for each tag during post creation