### PR TITLE
feat: add off-chain and on-chain post API routes with associated type…

### DIFF
--- a/src/app/api/v1/_v1_api-utils/types.ts
+++ b/src/app/api/v1/_v1_api-utils/types.ts
@@ -1,0 +1,221 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { EAllowedCommentor, ECommentSentiment, EProposalType, IStatusHistoryItem } from '@/_shared/types';
+
+export enum EV1ProposalType {
+	DEMOCRACY_PROPOSALS = 'democracy_proposals',
+	TECH_COMMITTEE_PROPOSALS = 'tech_committee_proposals',
+	TREASURY_PROPOSALS = 'treasury_proposals',
+	REFERENDUMS = 'referendums',
+	FELLOWSHIP_REFERENDUMS = 'fellowship_referendums',
+	COUNCIL_MOTIONS = 'council_motions',
+	BOUNTIES = 'bounties',
+	TIPS = 'tips',
+	CHILD_BOUNTIES = 'child_bounties',
+	OPEN_GOV = 'referendums_v2',
+	REFERENDUM_V2 = 'referendums_v2',
+	DISCUSSIONS = 'discussions',
+	GRANTS = 'grants',
+	ANNOUNCEMENT = 'announcement',
+	ALLIANCE_MOTION = 'alliance_motion',
+	TECHNICAL_PIPS = 'technical_pips',
+	UPGRADE_PIPS = 'upgrade_pips',
+	COMMUNITY_PIPS = 'community_pips',
+	ADVISORY_COMMITTEE = 'advisory_committee',
+	USER_CREATED_BOUNTIES = 'user_created_bounties'
+}
+
+export interface IReactionType {
+	'👍': {
+		count: number;
+		userIds: number[];
+		usernames: string[];
+	};
+	'👎': {
+		count: number;
+		userIds: number[];
+		usernames: string[];
+	};
+}
+
+export interface IOffChainPostsListing {
+	comments_count: number;
+	created_at: Date;
+	gov_type: string | null;
+	isSpam: boolean;
+	isSpamDetected: boolean;
+	isSpamReportInvalid: boolean;
+	post_id: number;
+	post_reactions: IReactionType;
+	proposer: string;
+	spam_users_count: number;
+	tags: string[];
+	title: string;
+	topic: number | null;
+	user_id: number;
+	username: string;
+}
+
+export interface IComment {
+	comment_reactions: IReactionType;
+	comment_source: string;
+	content: string;
+	created_at: Date;
+	history: {
+		content: string;
+		created_at: Date;
+		title: string;
+	}[];
+	id: string;
+	isExpertComment: boolean;
+	is_custom_username: boolean;
+	post_index: number;
+	post_type: string;
+	profile: {
+		achievement_badges: string[];
+		badges: string[];
+		social_links: string[];
+		bio: string;
+		cover_image: string;
+		email: string;
+		image: string;
+		title: string;
+	};
+	proposer: string;
+	replies?: IComment[];
+	sentiment: ECommentSentiment;
+	spam_users_count: number;
+	user_id: number;
+	username: string;
+}
+
+export interface IOffChainPost {
+	comments_count: number;
+	created_at: Date;
+	gov_type?: string | null;
+	isSpam: boolean;
+	isSpamDetected: boolean;
+	isSpamReportInvalid: boolean;
+	post_id: number;
+	post_reactions: IReactionType;
+	proposer: string;
+	spam_users_count: number;
+	tags: string[];
+	title: string;
+	topic: number | null;
+	user_id: number;
+	username: string;
+	content: string;
+	history: {
+		content: string;
+		created_at: Date;
+		title: string;
+	}[];
+	allowedCommentors: EAllowedCommentor;
+	comments: IComment[];
+	post_link: string | null;
+	post_type: EProposalType;
+	updated_at: Date;
+	timeline: {
+		created_at: Date;
+		index: number;
+		statuses: {
+			status: string;
+			timestamp: Date;
+		}[];
+		type: string;
+	}[];
+}
+
+export interface IBeneficiary {
+	address: string;
+	amount: string;
+	genralIndex: string | null;
+}
+
+export interface IOnChainPost {
+	comments_count: number;
+	created_at: Date;
+	post_id: number;
+	post_reactions: IReactionType;
+	proposer: string;
+	beneficiaries: IBeneficiary[];
+	statusHistory: IStatusHistoryItem[];
+	proposal_arguments: unknown;
+	tags: string[];
+	title: string;
+	topic?: number | null;
+	user_id: number;
+	username: string;
+	content: string;
+	history: {
+		content: string;
+		created_at: Date;
+		title: string;
+	}[];
+	allowedCommentors: EAllowedCommentor;
+	comments: IComment[];
+	post_link: string | null;
+	post_type: EProposalType;
+	updated_at: Date;
+	timeline: {
+		created_at: Date;
+		index: number;
+		statuses: {
+			status: string;
+			timestamp: Date;
+		}[];
+		type: string;
+	}[];
+	assetId: string | null;
+	bond: string | null;
+	curator: string | null;
+	curator_deposit: string | null;
+	dataSource: string;
+	deciding: {
+		confirming: number | null;
+		since: number;
+	} | null;
+	decision_deposit_amount: string;
+	delay: number | null;
+	deposit: string | null;
+	description: string | null;
+	enactment_after_block: number | null;
+	enactment_at_block: number | null;
+	end: string | null;
+	ended_at: string | null;
+	fee: string | null;
+	hash: string;
+	identity: unknown | null;
+	last_edited_at: string | null;
+	markdownContent: string;
+	method: string;
+	origin: string;
+	payee: string | null;
+	pips_voters: unknown[];
+	preimageHash: string;
+	proposalHashBlock: string | null;
+	proposed_call: {
+		method: string;
+		args: unknown;
+		description?: string;
+		section?: string;
+	};
+	requested?: string;
+	reward: string | null;
+	status: string;
+	submission_deposit_amount: string;
+	submitted_amount: string;
+	subscribers: number[];
+	tally: {
+		ayes: string;
+		bareAyes: string | null;
+		nays: string;
+		support: string;
+	};
+	track_number: number;
+	type: string;
+	progress_report: unknown[];
+}

--- a/src/app/api/v1/_v1_api-utils/utils.ts
+++ b/src/app/api/v1/_v1_api-utils/utils.ts
@@ -1,0 +1,145 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { ECommentSentiment, EProposalType, EReaction, ICommentResponse, IPost, IReaction } from '@/_shared/types';
+import { ERROR_CODES } from '@/_shared/_constants/errorLiterals';
+import { StatusCodes } from 'http-status-codes';
+import { EV1ProposalType, IReactionType } from './types';
+import { APIError } from '../../_api-utils/apiError';
+
+export function v1ToV2ProposalType(proposalType: EV1ProposalType): EProposalType {
+	switch (proposalType) {
+		case EV1ProposalType.DEMOCRACY_PROPOSALS:
+			return EProposalType.DEMOCRACY_PROPOSAL;
+		case EV1ProposalType.TECH_COMMITTEE_PROPOSALS:
+			return EProposalType.TECH_COMMITTEE_PROPOSAL;
+		case EV1ProposalType.TREASURY_PROPOSALS:
+			return EProposalType.TREASURY_PROPOSAL;
+		case EV1ProposalType.REFERENDUMS:
+			return EProposalType.REFERENDUM;
+		case EV1ProposalType.FELLOWSHIP_REFERENDUMS:
+			return EProposalType.FELLOWSHIP_REFERENDUM;
+		case EV1ProposalType.COUNCIL_MOTIONS:
+			return EProposalType.COUNCIL_MOTION;
+		case EV1ProposalType.BOUNTIES:
+			return EProposalType.BOUNTY;
+		case EV1ProposalType.TIPS:
+			return EProposalType.TIP;
+		case EV1ProposalType.CHILD_BOUNTIES:
+			return EProposalType.CHILD_BOUNTY;
+		case EV1ProposalType.OPEN_GOV:
+		case EV1ProposalType.REFERENDUM_V2:
+			return EProposalType.REFERENDUM_V2;
+		case EV1ProposalType.DISCUSSIONS:
+			return EProposalType.DISCUSSION;
+		case EV1ProposalType.GRANTS:
+			return EProposalType.GRANT;
+		case EV1ProposalType.ANNOUNCEMENT:
+			return EProposalType.ANNOUNCEMENT;
+		case EV1ProposalType.ALLIANCE_MOTION:
+			return EProposalType.ALLIANCE_MOTION;
+		case EV1ProposalType.TECHNICAL_PIPS:
+			return EProposalType.TECHNICAL_COMMITTEE;
+		case EV1ProposalType.UPGRADE_PIPS:
+			return EProposalType.UPGRADE_COMMITTEE;
+		case EV1ProposalType.COMMUNITY_PIPS:
+			return EProposalType.COMMUNITY;
+		case EV1ProposalType.ADVISORY_COMMITTEE:
+			return EProposalType.ADVISORY_COMMITTEE;
+		case EV1ProposalType.USER_CREATED_BOUNTIES:
+			return EProposalType.BOUNTY;
+		default:
+			throw new APIError(ERROR_CODES.BAD_REQUEST, StatusCodes.BAD_REQUEST, 'Invalid proposal type');
+	}
+}
+
+export const handleReactions = (reactions: IReaction[]) => {
+	const updatedReactions: IReactionType = {
+		'👍': {
+			count: 0,
+			userIds: [],
+			usernames: []
+		},
+		'👎': {
+			count: 0,
+			userIds: [],
+			usernames: []
+		}
+	};
+	reactions.forEach((reaction) => {
+		if (reaction.reaction === EReaction.like) {
+			updatedReactions['👍'].count += 1;
+		} else if (reaction.reaction === EReaction.dislike) {
+			updatedReactions['👎'].count += 1;
+		}
+	});
+	return updatedReactions;
+};
+
+export const getUpdatedComments = (comments: ICommentResponse[], post: IPost, proposalType: EProposalType, includeSubsquareComments: boolean) => {
+	let updatedComments =
+		comments?.map((comment) => {
+			return {
+				comment_reactions: handleReactions(comment.reactions || []),
+				comment_source: comment?.dataSource || 'polkassembly',
+				content: comment.content,
+				created_at: comment.createdAt || new Date(),
+				history: [],
+				id: comment.id,
+				isExpertComment: false,
+				is_custom_username: false,
+				post_index: post.index || 0,
+				post_type: proposalType,
+				proposer: comment?.user?.addresses[0] || '',
+				user_id: comment?.user?.id || 0,
+				username: comment?.user?.username || '',
+				sentiment: comment.sentiment || ECommentSentiment.NEUTRAL,
+				spam_users_count: 0,
+				profile: {
+					achievement_badges: [],
+					badges: [],
+					social_links: [],
+					bio: '',
+					cover_image: '',
+					email: '',
+					image: '',
+					title: ''
+				},
+				replies:
+					comment?.children?.map((child) => {
+						return {
+							comment_reactions: handleReactions(child.reactions || []),
+							comment_source: child?.dataSource || 'polkassembly',
+							content: child.content,
+							created_at: child.createdAt || new Date(),
+							history: [],
+							id: child.id,
+							isExpertComment: false,
+							is_custom_username: false,
+							post_index: post.index || 0,
+							post_type: proposalType,
+							proposer: child?.user?.addresses[0] || '',
+							sentiment: child.sentiment || ECommentSentiment.NEUTRAL,
+							spam_users_count: 0,
+							user_id: child?.user?.id || 0,
+							username: child?.user?.username || '',
+							profile: {
+								achievement_badges: [],
+								badges: [],
+								social_links: [],
+								bio: '',
+								cover_image: '',
+								email: '',
+								image: '',
+								title: ''
+							}
+						};
+					}) || []
+			};
+		}) || [];
+	if (!includeSubsquareComments) {
+		updatedComments = updatedComments.filter((comment) => comment.comment_source !== 'subsquare');
+	}
+	return updatedComments;
+};

--- a/src/app/api/v1/listing/off-chain-posts/route.ts
+++ b/src/app/api/v1/listing/off-chain-posts/route.ts
@@ -1,0 +1,114 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { NextResponse, NextRequest } from 'next/server';
+
+import { z } from 'zod';
+
+import { withErrorHandling } from '@/app/api/_api-utils/withErrorHandling';
+import { EProposalType, EReaction, IPostListing, IPublicUser } from '@/_shared/types';
+import { DEFAULT_LISTING_LIMIT, MAX_LISTING_LIMIT } from '@/_shared/_constants/listingLimit';
+import { getNetworkFromHeaders } from '@/app/api/_api-utils/getNetworkFromHeaders';
+import { headers } from 'next/headers';
+import { OffChainDbService } from '@/app/api/_api-services/offchain_db_service';
+import { ValidatorService } from '@/_shared/_services/validator_service';
+import { IReactionType, IOffChainPostsListing } from '../../_v1_api-utils/types';
+
+interface IGenericListingResponse<T> {
+	posts: T[];
+	count: number;
+}
+
+export const GET = withErrorHandling(async (req: NextRequest) => {
+	const proposalType = EProposalType.DISCUSSION;
+
+	const zodQuerySchema = z.object({
+		page: z.coerce.number().optional().default(1),
+		limit: z.coerce.number().max(MAX_LISTING_LIMIT).optional().default(DEFAULT_LISTING_LIMIT)
+	});
+
+	const searchParamsObject = Object.fromEntries(Array.from(req.nextUrl.searchParams.entries()).map(([key]) => [key, req.nextUrl.searchParams.getAll(key)]));
+
+	const { page, limit } = zodQuerySchema.parse(searchParamsObject);
+
+	const [network] = await Promise.all([getNetworkFromHeaders(), headers()]);
+
+	let posts: IPostListing[] = [];
+	let totalCount = 0;
+
+	posts = await OffChainDbService.GetOffChainPostsListing({
+		network,
+		proposalType,
+		limit,
+		page
+	});
+
+	totalCount = await OffChainDbService.GetTotalOffChainPostsCount({ network, proposalType });
+
+	const publicUserPromises = posts.map((post) => {
+		if (ValidatorService.isValidUserId(Number(post.userId || -1))) {
+			return OffChainDbService.GetPublicUserById(Number(post.userId));
+		}
+		if (post.onChainInfo?.proposer && ValidatorService.isValidWeb3Address(post.onChainInfo?.proposer || '')) {
+			return OffChainDbService.GetPublicUserByAddress(post.onChainInfo.proposer);
+		}
+		return null;
+	});
+
+	const publicUsers = await Promise.all(publicUserPromises);
+
+	posts = posts.map((post, index) => ({
+		...post,
+		...(publicUsers?.[Number(index)] ? { publicUser: publicUsers[Number(index)] as IPublicUser } : {})
+	}));
+
+	const updatedPosts: IOffChainPostsListing[] = posts.map((post) => {
+		const updatedReactions: IReactionType = {
+			'👍': {
+				count: 0,
+				userIds: [],
+				usernames: []
+			},
+			'👎': {
+				count: 0,
+				userIds: [],
+				usernames: []
+			}
+		};
+		if (post.reactions && post.reactions.length > 0) {
+			post.reactions.forEach((reaction) => {
+				if (reaction.reaction === EReaction.like) {
+					updatedReactions['👍'].count += 1;
+				} else if (reaction.reaction === EReaction.dislike) {
+					updatedReactions['👎'].count += 1;
+				}
+			});
+		}
+
+		return {
+			comments_count: post.metrics?.comments || 0,
+			created_at: post.createdAt || new Date(),
+			gov_type: null,
+			isSpam: false,
+			isSpamDetected: false,
+			isSpamReportInvalid: false,
+			post_id: post.index || 0,
+			post_reactions: updatedReactions,
+			proposer: post.publicUser?.addresses[0] || '',
+			spam_users_count: 0,
+			tags: post.tags?.map((tag) => tag.value) || [],
+			title: post.title || '',
+			topic: null,
+			user_id: post.publicUser?.id || 0,
+			username: post.publicUser?.username || ''
+		};
+	});
+
+	const response: IGenericListingResponse<IOffChainPostsListing> = {
+		posts: updatedPosts || [],
+		count: totalCount || 0
+	};
+
+	return NextResponse.json(response);
+});

--- a/src/app/api/v1/posts/off-chain-post/route.ts
+++ b/src/app/api/v1/posts/off-chain-post/route.ts
@@ -1,0 +1,128 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { NextResponse, NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withErrorHandling } from '@/app/api/_api-utils/withErrorHandling';
+import { EAllowedCommentor, ECommentSentiment, ICommentResponse } from '@/_shared/types';
+import { getNetworkFromHeaders } from '@/app/api/_api-utils/getNetworkFromHeaders';
+import { headers } from 'next/headers';
+import { OffChainDbService } from '@/app/api/_api-services/offchain_db_service';
+import { fetchPostData } from '../../../_api-utils/fetchPostData';
+import { EV1ProposalType, IOffChainPost } from '../../_v1_api-utils/types';
+import { handleReactions, v1ToV2ProposalType } from '../../_v1_api-utils/utils';
+
+export const GET = withErrorHandling(async (req: NextRequest) => {
+	const zodQuerySchema = z.object({
+		postId: z.string(),
+		proposalType: z.nativeEnum(EV1ProposalType).transform(v1ToV2ProposalType).default(EV1ProposalType.DISCUSSIONS),
+		noComments: z.boolean().optional().default(true)
+	});
+
+	const searchParamsObject = Object.fromEntries(Array.from(req.nextUrl.searchParams.entries()).map(([key, value]) => [key, value]));
+
+	const { postId, proposalType, noComments } = zodQuerySchema.parse(searchParamsObject);
+
+	const [network] = await Promise.all([getNetworkFromHeaders(), headers()]);
+
+	let post = await fetchPostData({
+		network,
+		proposalType,
+		indexOrHash: postId
+	});
+
+	const reactions = await OffChainDbService.GetPostReactions({ network, proposalType, indexOrHash: postId });
+	post = { ...post, reactions };
+
+	let comments: ICommentResponse[] = [];
+	if (!noComments) {
+		comments = await OffChainDbService.GetPostComments({ network, proposalType, indexOrHash: postId });
+	}
+
+	const updatedPost: IOffChainPost = {
+		comments_count: post.metrics?.comments || 0,
+		created_at: post.createdAt || new Date(),
+		isSpam: false,
+		isSpamDetected: false,
+		isSpamReportInvalid: false,
+		post_id: post.index || 0,
+		post_reactions: handleReactions(post.reactions || []),
+		proposer: post.publicUser?.addresses[0] || '',
+		spam_users_count: 0,
+		tags: post.tags?.map((tag) => tag.value) || [],
+		title: post.title || '',
+		topic: post.topic ? Number(post.topic) : 0,
+		user_id: post.publicUser?.id || 0,
+		username: post.publicUser?.username || '',
+		content: post.content || '',
+		history: [],
+		allowedCommentors: post.allowedCommentor || EAllowedCommentor.ALL,
+		comments:
+			comments?.map((comment) => {
+				return {
+					comment_reactions: handleReactions(comment.reactions || []),
+					comment_source: comment?.dataSource || 'polkassembly',
+					content: comment.content,
+					created_at: comment.createdAt || new Date(),
+					history: [],
+					id: comment.id,
+					isExpertComment: false,
+					is_custom_username: false,
+					post_index: post.index || 0,
+					post_type: proposalType,
+					proposer: comment?.user?.addresses[0] || '',
+					user_id: comment?.user?.id || 0,
+					username: comment?.user?.username || '',
+					sentiment: comment.sentiment || ECommentSentiment.NEUTRAL,
+					spam_users_count: 0,
+					profile: {
+						achievement_badges: [],
+						badges: [],
+						social_links: [],
+						bio: '',
+						cover_image: '',
+						email: '',
+						image: '',
+						title: ''
+					},
+					replies:
+						comment?.children?.map((child) => {
+							return {
+								comment_reactions: handleReactions(child.reactions || []),
+								comment_source: child?.dataSource || 'polkassembly',
+								content: child.content,
+								created_at: child.createdAt || new Date(),
+								history: [],
+								id: child.id,
+								isExpertComment: false,
+								is_custom_username: false,
+								post_index: post.index || 0,
+								post_type: proposalType,
+								proposer: child?.user?.addresses[0] || '',
+								sentiment: child.sentiment || ECommentSentiment.NEUTRAL,
+								spam_users_count: 0,
+								user_id: child?.user?.id || 0,
+								username: child?.user?.username || '',
+								profile: {
+									achievement_badges: [],
+									badges: [],
+									social_links: [],
+									bio: '',
+									cover_image: '',
+									email: '',
+									image: '',
+									title: ''
+								}
+							};
+						}) || []
+				};
+			}) || [],
+		post_link: null,
+		post_type: proposalType,
+		updated_at: post.updatedAt || new Date(),
+		timeline: []
+	};
+
+	return NextResponse.json(updatedPost);
+});

--- a/src/app/api/v1/posts/on-chain-post/route.ts
+++ b/src/app/api/v1/posts/on-chain-post/route.ts
@@ -1,0 +1,246 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { NextResponse, NextRequest } from 'next/server';
+import { z } from 'zod';
+import { withErrorHandling } from '@/app/api/_api-utils/withErrorHandling';
+import { EAllowedCommentor, ENetwork, EProposalType, ICommentResponse } from '@/_shared/types';
+import { getNetworkFromHeaders } from '@/app/api/_api-utils/getNetworkFromHeaders';
+import { headers } from 'next/headers';
+import { StatusCodes } from 'http-status-codes';
+import { ERROR_CODES } from '@/_shared/_constants/errorLiterals';
+import { OffChainDbService } from '@/app/api/_api-services/offchain_db_service';
+import { htmlToMarkdown } from '@/_shared/_utils/htmlToMarkdown';
+import { NETWORKS_DETAILS } from '@/_shared/_constants/networks';
+import { cacheExchange, Client as UrqlClient, fetchExchange } from '@urql/core';
+import { fetchPostData } from '../../../_api-utils/fetchPostData';
+import { APIError } from '../../../_api-utils/apiError';
+import { EV1ProposalType, IOnChainPost } from '../../_v1_api-utils/types';
+import { getUpdatedComments, handleReactions, v1ToV2ProposalType } from '../../_v1_api-utils/utils';
+
+const SUBSQUID_QUERY = `query ProposalByIndexAndType($index_eq: Int, $hash_eq: String, $type_eq: ProposalType) {
+  proposals(limit: 1, where: {type_eq: $type_eq, index_eq: $index_eq, hash_eq: $hash_eq}) {
+    index
+    proposer
+    status
+    proposalArguments{
+      args
+      section
+      method
+    }
+    preimage {
+      proposer
+      method
+      hash
+      proposedCall {
+        method
+        args
+        description
+        section
+      }
+    }
+    description
+    parentBountyIndex
+    hash
+    curator
+    type
+    threshold {
+      ... on MotionThreshold {
+        __typename
+        value
+      }
+      ... on ReferendumThreshold {
+        __typename
+        type
+      }
+    }
+    origin
+    trackNumber
+    end
+    createdAt
+    updatedAt
+    delay
+    endedAt
+    deposit
+    bond
+    reward
+    payee
+    fee
+    curatorDeposit
+    proposalArguments {
+      method
+      args
+      description
+      section
+    }
+    group {
+      proposals(limit: 25, orderBy: createdAt_ASC) {
+        type
+        statusHistory(limit: 25, orderBy: timestamp_ASC) {
+          status
+          timestamp
+          block
+        }
+        index
+        createdAt
+        proposer
+        preimage {
+          proposer
+        }
+        hash
+      }
+    }
+    statusHistory(limit: 25) {
+      timestamp
+      status
+      block
+    }
+    tally {
+      ayes
+      bareAyes
+      nays
+      support
+    }
+    enactmentAfterBlock
+    enactmentAtBlock
+    decisionDeposit {
+      amount
+      who
+    }
+    submissionDeposit {
+      amount
+      who
+    }
+    deciding {
+      confirming
+      since
+    }
+  }
+}
+`;
+
+const subsquidGqlClient = (network: ENetwork) => {
+	const subsquidUrl = NETWORKS_DETAILS[network.toString() as keyof typeof NETWORKS_DETAILS]?.subsquidUrl;
+
+	if (!subsquidUrl) {
+		throw new APIError(ERROR_CODES.INTERNAL_SERVER_ERROR, StatusCodes.INTERNAL_SERVER_ERROR, 'Subsquid URL not found for the given network');
+	}
+
+	return new UrqlClient({
+		url: subsquidUrl,
+		exchanges: [cacheExchange, fetchExchange]
+	});
+};
+
+export const GET = withErrorHandling(async (req: NextRequest) => {
+	const zodQuerySchema = z.object({
+		postId: z.string(),
+		proposalType: z.nativeEnum(EV1ProposalType).transform(v1ToV2ProposalType),
+		noComments: z.boolean().optional().default(false),
+		includeSubsquareComments: z.boolean().optional().default(true)
+	});
+
+	const searchParamsObject = Object.fromEntries(Array.from(req.nextUrl.searchParams.entries()).map(([key, value]) => [key, value]));
+
+	const { postId, proposalType, noComments, includeSubsquareComments } = zodQuerySchema.parse(searchParamsObject);
+
+	const [network] = await Promise.all([getNetworkFromHeaders(), headers()]);
+
+	let post = await fetchPostData({
+		network,
+		proposalType,
+		indexOrHash: postId
+	});
+
+	const reactions = await OffChainDbService.GetPostReactions({ network, proposalType, indexOrHash: postId });
+	post = { ...post, reactions };
+
+	let comments: ICommentResponse[] = [];
+	if (!noComments) {
+		comments = await OffChainDbService.GetPostComments({ network, proposalType, indexOrHash: postId });
+	}
+
+	const gqlClient = subsquidGqlClient(network);
+
+	const { data: subsquidData } = await gqlClient
+		.query(SUBSQUID_QUERY, { ...(proposalType === EProposalType.TIP ? { hash_eq: postId } : { index_eq: Number(postId) }), type_eq: proposalType })
+		.toPromise();
+
+	const postData = subsquidData?.proposals[0] || null;
+
+	// TODO: Add support for on-chain post
+	const preimage = postData?.preimage;
+	const proposalArguments = postData?.proposalArguments || postData?.callData;
+	const proposedCall = preimage?.proposedCall || postData?.proposalArguments?.args;
+
+	const updatedPost: IOnChainPost = {
+		allowedCommentors: post?.allowedCommentor || EAllowedCommentor.ALL,
+		assetId: null,
+		beneficiaries:
+			post?.onChainInfo?.beneficiaries?.map((beneficiary) => ({
+				address: beneficiary.address,
+				amount: beneficiary.amount,
+				genralIndex: beneficiary.assetId
+			})) || [],
+		bond: postData?.bond,
+		title: post?.title || '',
+		tags: post?.tags?.map((tag) => tag.value) || [],
+		comments: getUpdatedComments(comments, post, proposalType, includeSubsquareComments),
+		content: post?.content || '',
+		created_at: postData?.createdAt,
+		curator: postData?.curator,
+		curator_deposit: postData?.curatorDeposit,
+		dataSource: post?.dataSource || 'polkassembly',
+		deciding: postData?.deciding,
+		decision_deposit_amount: postData?.decisionDeposit?.amount,
+		delay: postData?.delay,
+		deposit: postData?.deposit,
+		description: postData?.description,
+		enactment_after_block: postData?.enactmentAfterBlock,
+		enactment_at_block: postData?.enactmentAtBlock,
+		end: postData?.end,
+		ended_at: postData?.endedAt,
+		fee: postData?.fee,
+		hash: postData?.hash || preimage?.hash,
+		history:
+			post?.history?.map((history) => ({
+				content: history.content || '',
+				created_at: history.createdAt,
+				title: history.title || ''
+			})) || [],
+		identity: postData?.identity || null,
+		last_edited_at: post?.updatedAt?.toDateString() || null,
+		markdownContent: htmlToMarkdown(post?.content || ''),
+		method: preimage?.method || proposedCall?.method || proposalArguments?.method,
+		origin: postData?.origin,
+		payee: postData?.payee,
+		pips_voters: postData?.voting || [],
+		user_id: post?.publicUser?.id || 0,
+		username: post?.publicUser?.username || '',
+		post_id: postData?.index,
+		post_reactions: handleReactions(postData?.reactions || []),
+		preimageHash: preimage?.hash || '',
+		proposalHashBlock: postData?.proposalHashBlock || null,
+		proposal_arguments: proposalArguments,
+		proposed_call: proposedCall,
+		proposer: postData?.proposer,
+		reward: postData?.reward,
+		status: postData?.status,
+		statusHistory: postData?.statusHistory,
+		submission_deposit_amount: postData?.submissionDeposit?.amount,
+		submitted_amount: postData?.submissionDeposit?.amount,
+		subscribers: [],
+		tally: postData?.tally,
+		timeline: [],
+		track_number: postData?.trackNumber,
+		type: postData?.type,
+		post_link: null,
+		post_type: proposalType,
+		updated_at: post?.updatedAt || new Date(),
+		progress_report: [],
+		comments_count: comments.length
+	};
+
+	return NextResponse.json(updatedPost);
+});


### PR DESCRIPTION
…s and utilities

- Introduced new API routes for off-chain and on-chain posts, enhancing the ability to fetch and manage posts.
- Created types for off-chain and on-chain posts, including detailed structures for comments, reactions, and proposal types.
- Implemented utility functions for handling reactions and converting proposal types between versions.
- Ensured integration with existing services and error handling mechanisms.