### PR TITLE
feat: implement user creation event handling and related API integration

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@ import * as logger from 'firebase-functions/logger';
 import { onSchedule } from 'firebase-functions/v2/scheduler';
 import * as dotenv from 'dotenv';
 import { HttpsError, onRequest } from 'firebase-functions/https';
+import { onDocumentWritten } from 'firebase-functions/v2/firestore';
 import { triggerFetchLatestTreasuryStats } from './utils/triggerFetchLatestTreasuryStats';
 import { ERROR_MESSAGES } from './constants';
 import { triggerCacheRefresh } from './utils/triggerCacheRefresh';
@@ -102,3 +103,67 @@ export const callCacheRefresh = onRequest(async (request, response) => {
 		throw new HttpsError('internal', 'Error in callCacheRefresh');
 	}
 });
+
+interface IUser {
+	email: string;
+	password: string;
+	username: string;
+	web3_signup: boolean;
+	custom_username: boolean;
+	salt: string;
+}
+
+// V2 implementation using the new syntax
+export const onUserWritten = onDocumentWritten(
+	{
+		document: 'users/{userId}',
+		region: 'us-central1',
+		maxInstances: 10
+	},
+	async (event) => {
+		try {
+			// If document was deleted or doesn't exist after write, no need to process
+			if (!event.data?.after) {
+				logger.info('User document was deleted or does not exist, no action needed');
+				return;
+			}
+
+			const userData = event.data.after.data();
+			if (!userData) {
+				logger.error('User data is undefined');
+				return;
+			}
+
+			const user: IUser = {
+				email: userData.email,
+				password: userData.password,
+				username: userData.username,
+				web3_signup: userData.isWeb3Signup || false,
+				custom_username: userData.custom_username,
+				salt: userData.salt
+			};
+
+			// Fix the URL (removed .ts extension)
+			const url = 'https://api.old-polkassembly.io/api/v1/users/createUser';
+
+			const response = await fetch(url, {
+				method: 'POST',
+				body: JSON.stringify(user),
+				headers: {
+					'Content-Type': 'application/json',
+					'x-tools-passphrase': process.env.TOOLS_PASSPHRASE || ''
+				}
+			});
+
+			if (!response.ok) {
+				const errorText = await response.text();
+				logger.error(`Error creating user: ${response.status} ${errorText}`);
+				return;
+			}
+
+			logger.info(`User successfully created with ID: ${event.data.after.id}`);
+		} catch (error) {
+			logger.error('Error in onUserWritten function:', error);
+		}
+	}
+);


### PR DESCRIPTION
- Added a new Firestore trigger  to handle user document writes, including user creation logic.
- Introduced a new webhook event  in the WebhookService to process user creation events.
- Implemented  method to add new users to the off-chain database and handle Web3 signup addresses.
- Updated user data structure to include necessary fields for user creation.