### PR TITLE
feat: add open graph image support for networks in metadata generation

### DIFF
--- a/src/_shared/_constants/networks.ts
+++ b/src/_shared/_constants/networks.ts
@@ -125,6 +125,10 @@ interface INetworkDetails {
 	palletInstance?: string;
 	parachain?: string;
 	convictionVotingPeriodInBlocks: BN;
+	openGraphImage?: {
+		large: string;
+		small: string;
+	};
 }
 
 enum ENetworkSocial {
@@ -1663,7 +1667,12 @@ export const NETWORKS_DETAILS: Record<ENetwork, INetworkDetails> = {
 		trackDetails: NETWORK_TRACK_DETAILS[ENetwork.POLKADOT],
 		socialLinks: networkSocialLinks[ENetwork.POLKADOT],
 		assethubDetails: ASSETHUB_DETAILS[ENetwork.POLKADOT],
-		convictionVotingPeriodInBlocks: new BN('100800')
+		convictionVotingPeriodInBlocks: new BN('100800'),
+		openGraphImage: {
+			large: 'https://firebasestorage.googleapis.com/v0/b/polkassembly-v2.firebasestorage.app/o/public%2Fpolkadot.png?alt=media&token=02231f8b-5206-4bff-ad78-9a64d81d6580',
+			small:
+				'https://firebasestorage.googleapis.com/v0/b/polkassembly-v2.firebasestorage.app/o/public%2Fpolkassembly-small.jpg?alt=media&token=63accae8-ea14-4705-817b-92c7bf80ccce'
+		}
 	},
 	[ENetwork.KUSAMA]: {
 		key: ENetwork.KUSAMA,

--- a/src/app/referenda/[index]/page.tsx
+++ b/src/app/referenda/[index]/page.tsx
@@ -10,13 +10,19 @@ import { headers } from 'next/headers';
 import { Metadata } from 'next';
 import { OPENGRAPH_METADATA } from '@/_shared/_constants/opengraphMetadata';
 import PollForProposal from '@/app/_shared-components/PollForProposal';
+import { getNetworkFromHeaders } from '@/app/api/_api-utils/getNetworkFromHeaders';
+import { NETWORKS_DETAILS } from '@/_shared/_constants/networks';
 
 export async function generateMetadata({ params }: { params: Promise<{ index: string }> }): Promise<Metadata> {
 	const { index } = await params;
+
+	const network = await getNetworkFromHeaders();
 	const { data } = await NextApiClientService.fetchProposalDetails({ proposalType: EProposalType.REFERENDUM_V2, indexOrHash: index });
 
 	// Default description and title
 	let { description, title } = OPENGRAPH_METADATA;
+	const image = NETWORKS_DETAILS[`${network}`].openGraphImage?.large;
+	const smallImage = NETWORKS_DETAILS[`${network}`].openGraphImage?.small;
 
 	// Use post title in description if available
 	if (data) {
@@ -24,9 +30,41 @@ export async function generateMetadata({ params }: { params: Promise<{ index: st
 		description = `Referendum #${index}: ${data.contentSummary?.postSummary ? data.contentSummary.postSummary : data.title}`;
 	}
 
+	const url = `https://polkassembly.com/referenda/${index}`;
+
 	return {
 		title,
-		description
+		description,
+		metadataBase: new URL('https://polkassembly.com'),
+		icons: [{ url: '/favicon.ico' }],
+		openGraph: {
+			title,
+			description,
+			images: [
+				{
+					url: image || '',
+					width: 1200,
+					height: 630,
+					alt: `Polkassembly Referendum #${index}`
+				},
+				{
+					url: smallImage || '',
+					width: 600,
+					height: 600,
+					alt: `Polkassembly Referendum #${index}`
+				}
+			],
+			siteName: 'Polkassembly',
+			type: 'website',
+			url
+		},
+		twitter: {
+			card: 'summary_large_image',
+			title,
+			description,
+			images: image ? [image] : [],
+			site: '@polkassembly'
+		}
 	};
 }
 


### PR DESCRIPTION
- Introduced openGraphImage property in INetworkDetails interface to store large and small image URLs for each network.
- Updated generateMetadata function to include open graph images for referenda, enhancing social media sharing capabilities with appropriate images for each network.