### PR TITLE
fix: adjust image dimensions in metadata generation for referenda

### DIFF
--- a/src/app/referenda/[index]/page.tsx
+++ b/src/app/referenda/[index]/page.tsx
@@ -43,13 +43,13 @@ export async function generateMetadata({ params }: { params: Promise<{ index: st
 			images: [
 				{
 					url: image || '',
-					width: 1200,
-					height: 630,
+					width: 600,
+					height: 600,
 					alt: `Polkassembly Referendum #${index}`
 				},
 				{
 					url: smallImage || '',
-					width: 600,
+					width: 1200,
 					height: 600,
 					alt: `Polkassembly Referendum #${index}`
 				}


### PR DESCRIPTION
- Updated the width and height of the large and small images in the generateMetadata function to ensure proper display in open graph metadata, enhancing visual consistency across platforms.