### PR TITLE
fix: update default value for noComments in off-chain post route

### DIFF
--- a/src/app/api/v1/posts/off-chain-post/route.ts
+++ b/src/app/api/v1/posts/off-chain-post/route.ts
@@ -17,7 +17,7 @@ export const GET = withErrorHandling(async (req: NextRequest) => {
 	const zodQuerySchema = z.object({
 		postId: z.string(),
 		proposalType: z.nativeEnum(EV1ProposalType).transform(v1ToV2ProposalType).default(EV1ProposalType.DISCUSSIONS),
-		noComments: z.coerce.boolean().optional().default(true)
+		noComments: z.coerce.boolean().optional().default(false)
 	});
 
 	const searchParamsObject = Object.fromEntries(Array.from(req.nextUrl.searchParams.entries()).map(([key, value]) => [key, value]));


### PR DESCRIPTION
- Changed the default value of noComments from true to false in the off-chain post route schema, ensuring comments are fetched by default unless specified otherwise.