### PR TITLE
feat: enhance reaction handling in FirestoreService and utils

### DIFF
--- a/src/_shared/types.ts
+++ b/src/_shared/types.ts
@@ -346,6 +346,7 @@ export interface IReaction {
 	createdAt: Date;
 	updatedAt: Date;
 	commentId?: string;
+	publicUser?: IPublicUser;
 }
 
 export interface IPostOffChainMetrics {

--- a/src/app/api/v1/_v1_api-utils/utils.ts
+++ b/src/app/api/v1/_v1_api-utils/utils.ts
@@ -70,8 +70,12 @@ export const handleReactions = (reactions: IReaction[]) => {
 	reactions.forEach((reaction) => {
 		if (reaction.reaction === EReaction.like) {
 			updatedReactions['👍'].count += 1;
+			updatedReactions['👍'].userIds.push(reaction.userId);
+			updatedReactions['👍'].usernames.push(reaction.publicUser?.username || '');
 		} else if (reaction.reaction === EReaction.dislike) {
 			updatedReactions['👎'].count += 1;
+			updatedReactions['👎'].userIds.push(reaction.userId);
+			updatedReactions['👎'].usernames.push(reaction.publicUser?.username || '');
 		}
 	});
 	return updatedReactions;


### PR DESCRIPTION
- Added publicUser information to IReaction interface for improved user context.
- Updated GetPostReactions and GetCommentReactions methods to fetch publicUser details asynchronously.
- Modified handleReactions utility to include publicUser usernames in reaction counts, enhancing user engagement tracking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Reactions now include public user information, allowing you to see details about users who reacted.
- **Enhancements**
	- Reaction data now provides user IDs and usernames for each "like" and "dislike," giving more insight into who participated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->