### PR TITLE
Fix sorting issue for search results

### DIFF
--- a/src/app/api/_api-services/offchain_db_service/index.ts
+++ b/src/app/api/_api-services/offchain_db_service/index.ts
@@ -229,7 +229,7 @@ export class OffChainDbService {
 		const buildCommentTree = (parentId: string | null): ICommentResponse[] => {
 			return allCommentsWithReactions
 				.filter((comment) => comment.parentCommentId === parentId)
-				.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()) // Sort by creation date, oldest first
+				.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()) // Sort by creation date, latest first
 				.map((comment) => ({
 					...comment,
 					children: buildCommentTree(comment.id)


### PR DESCRIPTION
A sorting bug was identified in the `src/app/api/_api-services/offchain_db_service/index.ts` file. Comments were being sorted by creation date in ascending order (oldest first), which contradicted the requirement for search results on PA to be sorted by date, latest first.

The fix involved modifying the `sort` method within the `buildCommentTree` function. The comparison logic was changed from `a.createdAt.getTime() - b.createdAt.getTime()` to `b.createdAt.getTime() - a.createdAt.getTime()`.

This change ensures that:
*   Comments and search results now display with the latest items first.
*   The default sorting behavior aligns with the specified requirement of "by date, latest first always."