### PR TITLE
refactor: remove redundant state reset in VoteHistory component

### DIFF
--- a/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistory.module.scss
+++ b/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistory.module.scss
@@ -5,7 +5,3 @@
 .tableContainer {
 	@apply relative flex max-h-[500px] flex-col;
 }
-
-.table {
-	@apply min-h-[200px];
-}

--- a/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistory.tsx
+++ b/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistory.tsx
@@ -25,7 +25,6 @@ function VoteHistory({ proposalType, index, votesDisplayType }: { proposalType: 
 
 	// Reset all state variables to initial values when votesType changes
 	useEffect(() => {
-		setTab(EVoteDecision.AYE);
 		setPage(1);
 		setSortBy(EVoteSortOptions.CreatedAtBlockDESC);
 	}, [votesDisplayType]);

--- a/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistoryTable.tsx
+++ b/src/app/_shared-components/PostDetails/VoteSummary/VoteHistory/VoteHistoryTable.tsx
@@ -132,7 +132,7 @@ function VoteHistoryTable({
 					{t('PostDetails.noVotes')}
 				</div>
 			) : (
-				<Table className={classes.table}>
+				<Table>
 					<TableHeader className='w-full'>
 						{table.getHeaderGroups().map((headerGroup) => (
 							<TableRow key={headerGroup.id}>


### PR DESCRIPTION
- Removed the line that sets the tab to EVoteDecision.AYE when votesDisplayType changes, streamlining the state reset logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table styling in the vote history section by removing a minimum height constraint.

* **Refactor**
  * Improved state management in the vote history view to preserve the selected tab when changing display types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->