### PR TITLE
refactor: streamline Firestore query conditions in GetPollForPost method

### DIFF
--- a/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
+++ b/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
@@ -1673,12 +1673,7 @@ export class FirestoreService extends FirestoreUtils {
 	}
 
 	static async GetPollForPost({ network, index, proposalType }: { network: ENetwork; index: number; proposalType: EProposalType }) {
-		const pollSnapshot = await this.pollsCollectionRef()
-			.where('network', '==', network)
-			.where('proposalType', '==', proposalType)
-			.where('index', '==', String(index))
-			.limit(1)
-			.get();
+		const pollSnapshot = await this.pollsCollectionRef().where('network', '==', network).where('proposalType', '==', proposalType).where('index', '==', index).limit(1).get();
 
 		if (!pollSnapshot.docs?.length) {
 			return null;
@@ -1734,7 +1729,7 @@ export class FirestoreService extends FirestoreUtils {
 		const pollSnapshot = await this.pollsCollectionRef()
 			.where('network', '==', network)
 			.where('proposalType', '==', proposalType)
-			.where('index', '==', String(index))
+			.where('index', '==', index)
 			.where('id', '==', pollId)
 			.limit(1)
 			.get();
@@ -1768,7 +1763,7 @@ export class FirestoreService extends FirestoreUtils {
 		const pollSnapshot = await this.pollsCollectionRef()
 			.where('network', '==', network)
 			.where('proposalType', '==', proposalType)
-			.where('index', '==', String(index))
+			.where('index', '==', index)
 			.where('id', '==', pollId)
 			.get();
 


### PR DESCRIPTION
- Consolidated multiple where conditions into a single line for improved readability.
- Updated index comparison to use a number instead of a string for consistency across the Firestore queries.