### PR TITLE
refactor: rename user posts API route and method for clarity

### DIFF
--- a/src/app/_client-services/next_api_client_service.ts
+++ b/src/app/_client-services/next_api_client_service.ts
@@ -137,7 +137,7 @@ enum EApiRoute {
 	GET_VOTE_CURVES = 'GET_VOTE_CURVES',
 	GET_CONTENT_SUMMARY = 'GET_CONTENT_SUMMARY',
 	GET_TRACK_ANALYTICS = 'GET_TRACK_ANALYTICS',
-	GET_USER_POSTS = 'GET_USER_POSTS',
+	GET_USER_POSTS_BY_ADDRESS = 'GET_USER_POSTS_BY_ADDRESS',
 	GET_POLL_VOTES = 'GET_POLL_VOTES',
 	ADD_POLL_VOTE = 'ADD_POLL_VOTE',
 	DELETE_POLL_VOTE = 'DELETE_POLL_VOTE',
@@ -214,7 +214,7 @@ export class NextApiClientService {
 				break;
 			case EApiRoute.GET_ADDRESS_RELATIONS:
 			case EApiRoute.PUBLIC_USER_DATA_BY_ADDRESS:
-			case EApiRoute.GET_USER_POSTS:
+			case EApiRoute.GET_USER_POSTS_BY_ADDRESS:
 				path = '/users/address';
 				break;
 
@@ -1116,12 +1116,12 @@ export class NextApiClientService {
 		};
 	}
 
-	static async getUserPosts({ address, page, limit }: { address: string; page: number; limit: number }) {
+	static async getUserPostsByAddress({ address, page, limit }: { address: string; page: number; limit: number }) {
 		const queryParams = new URLSearchParams({
 			page: page.toString(),
 			limit: limit.toString()
 		});
-		const { url, method } = await this.getRouteConfig({ route: EApiRoute.GET_USER_POSTS, routeSegments: [address, 'posts'], queryParams });
+		const { url, method } = await this.getRouteConfig({ route: EApiRoute.GET_USER_POSTS_BY_ADDRESS, routeSegments: [address, 'posts'], queryParams });
 		return this.nextApiClientFetch<IUserPosts>({ url, method });
 	}
 

--- a/src/app/_shared-components/Profile/Posts/Posts.tsx
+++ b/src/app/_shared-components/Profile/Posts/Posts.tsx
@@ -33,7 +33,7 @@ function Posts({ addresses }: { addresses: string[] }) {
 	const [selectedPosts, setSelectedPosts] = useState<EPostsType>(EPostsType.OPEN_GOV);
 
 	const fetchUserPosts = async () => {
-		const { data: userPostsData, error: userPostsError } = await NextApiClientService.getUserPosts({
+		const { data: userPostsData, error: userPostsError } = await NextApiClientService.getUserPostsByAddress({
 			address: getEncodedAddress(selectedAddress, network) || '',
 			page,
 			limit: DEFAULT_LISTING_LIMIT

--- a/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
+++ b/src/app/api/_api-services/offchain_db_service/firestore_service/index.ts
@@ -1630,15 +1630,21 @@ export class FirestoreService extends FirestoreUtils {
 			.offset((page - 1) * limit)
 			.get();
 
-		return {
-			items: posts.docs.map((doc) => {
+		const postsWithMetrics = await Promise.all(
+			posts.docs.map(async (doc) => {
 				const data = doc.data();
+				const metrics = await this.GetPostMetrics({ network, indexOrHash: String(data.index), proposalType });
 				return {
 					...data,
+					metrics,
 					createdAt: data.createdAt?.toDate(),
 					updatedAt: data.updatedAt?.toDate()
 				} as IOffChainPost;
-			}),
+			})
+		);
+
+		return {
+			items: postsWithMetrics,
 			totalCount: totalCount.data().count
 		};
 	}


### PR DESCRIPTION
- Updated the API route from GET_USER_POSTS to GET_USER_POSTS_BY_ADDRESS for better specificity.
- Refactored the corresponding method in NextApiClientService to getUserPostsByAddress.
- Adjusted the Posts component to utilize the new method for fetching user posts by address.
- Enhanced FirestoreService to return post metrics alongside post data for improved functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User posts now display additional metrics for each post.

* **Refactor**
  * Renamed certain methods and enum values related to fetching user posts to improve clarity. No impact on how you interact with the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->