### PR TITLE
Update Content Security Policy in next.config.mjs to include addition…

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -38,7 +38,7 @@ const nextConfig = {
 							"object-src 'none'",
 							"base-uri 'self'",
 							"form-action 'self'",
-							"connect-src 'self' https://api.github.com https://*.polkassembly.io https://*.firebaseapp.com https://*.googleapis.com https://sentry.io https://o4504609384013824.ingest.sentry.io wss: https://www.google-analytics.com",
+							"connect-src 'self' https://api.github.com https://*.polkassembly.io https://*.firebaseapp.com https://*.googleapis.com https://sentry.io https://o4504609384013824.ingest.sentry.io wss: https://www.google-analytics.com https://*.algolia.net https://*.algolianet.com https://*.algolia.io https://api.imgbb.com https://www.googletagmanager.com",
 							`frame-src 'self' ${ALLOWED_OUTBOUND_IFRAME_DOMAINS.join(' ')}`,
 							`frame-ancestors 'self' ${ALLOWED_OUTBOUND_IFRAME_DOMAINS.join(' ')}`,
 							'upgrade-insecure-requests'


### PR DESCRIPTION
…al Algolia and ImgBB domains for connect-src.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded Content Security Policy (connect-src) to allow additional trusted domains: https://*.algolia.net, https://*.algolianet.com, https://*.algolia.io, https://api.imgbb.com, and https://www.googletagmanager.com. All previously allowed origins remain (e.g., Google Analytics, GitHub API, Polkassembly, Firebase, Google APIs, Sentry, and wss). frame-src and frame-ancestors directives are unchanged. This enables smoother connectivity with these services under stricter security controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->