### PR TITLE
fix table breaking in post detail view by allowing horizontal scroll

### DIFF
--- a/src/app/_shared-components/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/app/_shared-components/MarkdownViewer/MarkdownViewer.tsx
@@ -84,7 +84,11 @@ const getEmbedUrl = (url: string): string | null => {
 
 const markdownComponents: Components = {
 	div: 'div',
-	table: 'table',
+	table: ({ children, ...props }) => (
+		<div className='w-full overflow-x-scroll'>
+			<table {...props}>{children}</table>
+		</div>
+	),
 	thead: 'thead',
 	tbody: 'tbody',
 	tr: 'tr',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown tables now scroll horizontally when content is wider than the viewport, improving readability on small screens and preventing layout overflow.
  * Tables are wrapped in a scrollable container while preserving the original table structure and behavior (headers, rows, cells remain unchanged).
  * This enhancement applies wherever MarkdownViewer is used, ensuring consistent display of wide tables without truncation or layout breaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->