### PR TITLE
Update network constants and RPC endpoints in networks.ts

### DIFF
--- a/src/_shared/_constants/networks.ts
+++ b/src/_shared/_constants/networks.ts
@@ -38,7 +38,16 @@ const VIA_IBP_GEODNS1 = 'via IBP-GeoDNS1';
 const VIA_IBP_GEODNS2 = 'via IBP-GeoDNS2';
 const VIA_RADIUMBLOCK = 'via RadiumBlock';
 const VIA_LUCKYFRIDAY = 'via LuckyFriday';
-const VIA_PINKNODE = 'via Pinknode';
+const VIA_ALL_NODES = 'via All Nodes';
+const VIA_BLOCKOPS = 'via Blockops';
+const VIA_DWELLIR_TUNISIA = 'via Dwellir Tunisia';
+const VIA_HELIXSTREET = 'via HelixStreet';
+const VIA_IBP_1 = 'via IBP 1';
+const VIA_IBP_2 = 'via IBP 2';
+const VIA_PERMANENCE_DAO_EU = 'via Permanence DAO EU';
+const VIA_STAKETWORLD = 'via Stakeworld';
+const VIA_SIMPLY_STAKING = 'via Simply Staking';
+const VIA_SUBQUERY = 'via SubQuery';
 
 interface ITreasuryAsset {
 	name: string;
@@ -2485,36 +2494,60 @@ export const NETWORKS_DETAILS: Record<ENetwork, INetworkDetails> = {
 		tokenSymbol: 'DOT',
 		rpcEndpoints: [
 			{
-				name: `${VIA_PARITY} (recommended)`,
-				url: 'wss://rpc.polkadot.io'
+				name: `${VIA_ALL_NODES} (recommended)`,
+				url: 'wss://polkadot-rpc.publicnode.com'
+			},
+			{
+				name: VIA_BLOCKOPS,
+				url: 'wss://polkadot-public-rpc.blockops.network/ws'
+			},
+			{
+				name: VIA_DWELLIR,
+				url: 'wss://polkadot-rpc.n.dwellir.com'
+			},
+			{
+				name: VIA_DWELLIR_TUNISIA,
+				url: 'wss://polkadot-rpc-tn.dwellir.com'
+			},
+			{
+				name: VIA_HELIXSTREET,
+				url: 'wss://rpc-polkadot.helixstreet.io'
+			},
+			{
+				name: VIA_IBP_1,
+				url: 'wss://rpc.ibp.network/polkadot'
+			},
+			{
+				name: VIA_IBP_2,
+				url: 'wss://polkadot.dotters.network'
+			},
+			{
+				name: VIA_LUCKYFRIDAY,
+				url: 'wss://rpc-polkadot.luckyfriday.io'
+			},
+			{
+				name: VIA_PERMANENCE_DAO_EU,
+				url: 'wss://rpc.permanence.io'
 			},
 			{
 				name: VIA_ONFINALITY,
 				url: 'wss://polkadot.api.onfinality.io/public-ws'
 			},
 			{
-				name: VIA_DWELLIR,
-				url: 'wss://polkadot-rpc.dwellir.com'
-			},
-			{
-				name: VIA_PINKNODE,
-				url: 'wss://public-rpc.pinknode.io/polkadot'
-			},
-			{
-				name: VIA_IBP_GEODNS1,
-				url: 'wss://rpc.ibp.network/polkadot'
-			},
-			{
-				name: VIA_IBP_GEODNS2,
-				url: 'wss://rpc.dotters.network/polkadot'
+				name: VIA_PERMANENCE_DAO_EU,
+				url: 'wss://polkadot.rpc.permanence.io'
 			},
 			{
 				name: VIA_RADIUMBLOCK,
 				url: 'wss://polkadot.public.curie.radiumblock.co/ws'
 			},
 			{
-				name: VIA_LUCKYFRIDAY,
-				url: 'wss://rpc-polkadot.luckyfriday.io'
+				name: VIA_ONFINALITY,
+				url: 'wss://polkadot.api.onfinality.io/public-ws'
+			},
+			{
+				name: VIA_PERMANENCE_DAO_EU,
+				url: 'wss://polkadot.rpc.permanence.io'
 			}
 		],
 		supportedAssets: {
@@ -2595,8 +2628,16 @@ export const NETWORKS_DETAILS: Record<ENetwork, INetworkDetails> = {
 				url: 'wss://kusama.public.curie.radiumblock.co/ws'
 			},
 			{
-				name: VIA_LUCKYFRIDAY,
-				url: 'wss://rpc-kusama.luckyfriday.io'
+				name: VIA_SIMPLY_STAKING,
+				url: 'wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/LjwBJpV3dIKyWQ/polkadot/mainnet/'
+			},
+			{
+				name: VIA_STAKETWORLD,
+				url: 'wss://dot-rpc.stakeworld.io'
+			},
+			{
+				name: VIA_SUBQUERY,
+				url: 'wss://polkadot.rpc.subquery.network/public/ws'
 			}
 		],
 		peopleChainDetails: PEOPLE_CHAIN_NETWORK_DETAILS[ENetwork.KUSAMA],
@@ -2642,19 +2683,19 @@ export const NETWORKS_DETAILS: Record<ENetwork, INetworkDetails> = {
 				url: 'wss://rpc-westend.luckyfriday.io'
 			},
 			{
-				name: 'via OnFinality',
+				name: VIA_ONFINALITY,
 				url: 'wss://westend.api.onfinality.io/public-ws'
 			},
 			{
-				name: 'via Parity',
+				name: VIA_PARITY,
 				url: 'wss://westend-rpc.polkadot.io'
 			},
 			{
-				name: 'via RadiumBlock',
+				name: VIA_RADIUMBLOCK,
 				url: 'wss://westend.public.curie.radiumblock.co/ws'
 			},
 			{
-				name: 'via Stakeworld',
+				name: VIA_STAKETWORLD,
 				url: 'wss://wnd-rpc.stakeworld.io'
 			}
 		],


### PR DESCRIPTION
- Added new network constants for various RPC providers including All Nodes, Blockops, Dwellir Tunisia, HelixStreet, and others.
- Updated existing RPC endpoint URLs to reflect new providers and ensure accurate connections.
- Enhanced the overall network configuration for improved functionality and user experience.