### PR TITLE
removed account alert from add comment

### DIFF
--- a/src/app/_shared-components/AddressRelationsPicker/AddressRelationsPicker.tsx
+++ b/src/app/_shared-components/AddressRelationsPicker/AddressRelationsPicker.tsx
@@ -196,7 +196,17 @@ function AddressRadioGroup({ accountType, addresses, defaultOpen = false, closeD
 	);
 }
 
-function AddressSwitchButton({ disabled, showLinkedAccountBadge = false, className }: { disabled?: boolean; showLinkedAccountBadge?: boolean; className?: string }) {
+function AddressSwitchButton({
+	disabled,
+	showLinkedAccountBadge = false,
+	className,
+	switchButtonText
+}: {
+	disabled?: boolean;
+	showLinkedAccountBadge?: boolean;
+	className?: string;
+	switchButtonText?: string;
+}) {
 	const { user } = useUser();
 	const { userPreferences } = useUserPreferences();
 	const [isOpen, setisOpen] = useState(false);
@@ -220,7 +230,7 @@ function AddressSwitchButton({ disabled, showLinkedAccountBadge = false, classNa
 					className={cn('ml-auto flex items-center gap-1 text-xs', className)}
 					disabled={disabled}
 				>
-					<IoMdSync /> {t('Switch')}
+					<IoMdSync /> {switchButtonText || t('Switch')}
 				</Button>
 			</DialogTrigger>
 			<DialogContent className='max-w-xl p-3 sm:p-6'>
@@ -409,6 +419,7 @@ export default function AddressRelationsPicker({
 						disabled={disabled}
 						showLinkedAccountBadge={showLinkedAccountBadge}
 						className={switchButtonClassName}
+						switchButtonText={t('AddressRelationsPicker.switchWallet')}
 					/>
 				) : (
 					<Alert

--- a/src/app/_shared-components/AddressRelationsPicker/AddressRelationsPicker.tsx
+++ b/src/app/_shared-components/AddressRelationsPicker/AddressRelationsPicker.tsx
@@ -272,7 +272,8 @@ export default function AddressRelationsPicker({
 	showLinkedAccountBadge = false,
 	iconSize = 25,
 	className,
-	switchButtonClassName
+	switchButtonClassName,
+	hideAccountsAlert = false
 }: {
 	withBalance?: boolean;
 	showPeopleChainBalance?: boolean;
@@ -282,6 +283,7 @@ export default function AddressRelationsPicker({
 	iconSize?: number;
 	className?: string;
 	switchButtonClassName?: string;
+	hideAccountsAlert?: boolean;
 }) {
 	const { userPreferences, setUserPreferences } = useUserPreferences();
 	const walletService = useWalletService();
@@ -402,6 +404,12 @@ export default function AddressRelationsPicker({
 						</ul>
 						<Button onClick={() => setOpenVaultModal(true)}>{t('PolkadotVault.scan')}</Button>
 					</div>
+				) : hideAccountsAlert ? (
+					<AddressSwitchButton
+						disabled={disabled}
+						showLinkedAccountBadge={showLinkedAccountBadge}
+						className={switchButtonClassName}
+					/>
 				) : (
 					<Alert
 						variant='info'

--- a/src/app/_shared-components/PostComments/AddComment/AddComment.tsx
+++ b/src/app/_shared-components/PostComments/AddComment/AddComment.tsx
@@ -257,7 +257,7 @@ function AddComment({
 	return (
 		<div className='flex flex-col gap-2'>
 			<div
-				className='-ml-2 flex w-full'
+				className='flex w-full'
 				id={id}
 			>
 				<AddressSwitchButton
@@ -267,6 +267,7 @@ function AddComment({
 					className='w-full gap-0 border-none pl-0'
 					iconSize={30}
 					switchButtonClassName='px-2 text-[8px] h-6'
+					hideAccountsAlert
 				/>
 			</div>
 			<div className='mb-2'>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Address selection can now hide the “no accounts” alert and show a direct switch button instead; disabled state and linked-account badge are preserved. Switch button label can be customized.

- Style
  - Fixed alignment in the Add Comment input by removing a subtle left offset for a cleaner layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->