### PR TITLE
increased line clamp in post content

### DIFF
--- a/src/app/_shared-components/MarkdownViewer/MarkdownViewer.tsx
+++ b/src/app/_shared-components/MarkdownViewer/MarkdownViewer.tsx
@@ -271,12 +271,12 @@ interface ReactMarkdownProps {
 	markdown: string;
 	className?: string;
 	truncate?: boolean;
-	maxLines?: number;
+	lineClampClassName?: string;
 	onShowMore?: () => void;
 }
 
 export function MarkdownViewer(props: ReactMarkdownProps) {
-	const { markdown, className, truncate = false, maxLines = 4, onShowMore } = props;
+	const { markdown, className, truncate = false, lineClampClassName, onShowMore } = props;
 	const [showMore, setShowMore] = useState(false);
 	const [isTruncated, setIsTruncated] = useState(false);
 	const editorRef = useRef<HTMLDivElement>(null);
@@ -332,7 +332,7 @@ export function MarkdownViewer(props: ReactMarkdownProps) {
 		<div className='w-full'>
 			<div
 				ref={editorRef}
-				className={cn('markdown-body', truncate && !showMore ? `line-clamp-${maxLines}` : 'line-clamp-none', 'w-full', className)}
+				className={cn('markdown-body', truncate && !showMore ? lineClampClassName || 'line-clamp-4' : 'line-clamp-none', 'w-full', className)}
 			>
 				<HighlightMenu markdownRef={editorRef} />
 				<ReactMarkdownLib

--- a/src/app/_shared-components/PostDetails/PostContent.tsx
+++ b/src/app/_shared-components/PostDetails/PostContent.tsx
@@ -48,6 +48,7 @@ function PostContent({ postData, isModalOpen }: { postData: IPost; isModalOpen: 
 					markdown={content}
 					className={cn(isModalOpen ? '' : 'max-h-full border-none')}
 					truncate
+					lineClampClassName='line-clamp-[12]'
 				/>
 			)}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Post content now displays up to 12 lines of markdown before “Show More/Show Less,” improving readability. Truncation behavior and expand/collapse controls remain unchanged.
- Refactor
  - Markdown viewer configuration updated to use a line-clamp CSS class instead of a numeric max-lines setting. Defaults to a 4-line clamp when unspecified. Developers may need to update integrations to the new configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->