### PR TITLE
validation fix for twitter usernames

### DIFF
--- a/src/_shared/_services/validator_service.ts
+++ b/src/_shared/_services/validator_service.ts
@@ -308,8 +308,8 @@ export class ValidatorService {
 		// Twitter handle rules:
 		// - 4-15 characters long
 		// - Only alphanumeric characters and underscores
-		// - Can start with a letter or number (no leading underscore)
-		const twitterHandleRegex = /^[a-zA-Z0-9][a-zA-Z0-9_]{3,14}$/;
+		// - Can start with a letter or number or underscore (@0x, @_abc)
+		const twitterHandleRegex = /^[a-zA-Z0-9_][a-zA-Z0-9_]{3,14}$/;
 
 		return twitterHandleRegex.test(cleanHandle);
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Twitter handle validation updated to accept usernames that start with a letter, number, or underscore, reducing false rejections during input.
  * Maintains existing length (4–15) and allowed characters (letters, numbers, underscores).
  * No changes to public APIs or user-facing settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->