### PR TITLE
Add border to DialogTrigger component in VotesData

### DIFF
--- a/src/app/_shared-components/PostDetails/VotesData/VotesData.tsx
+++ b/src/app/_shared-components/PostDetails/VotesData/VotesData.tsx
@@ -274,7 +274,7 @@ function VotesData({ proposalType, index, trackName, createdAt, timeline, setThr
 				<Dialog>
 					<DialogTrigger
 						asChild
-						className='mt-6'
+						className='mt-6 border border-border_grey'
 					>
 						<Button
 							variant='outline'


### PR DESCRIPTION
Enhance the visual appearance of the DialogTrigger component by adding a border.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * The Vote History button now displays a visible border, aligning with overall button styling across the app.
  * Visual polish only: interaction, behavior, and data remain unchanged.
  * Improves consistency across themes and better distinguishes the control from surrounding content.
  * No impact to performance or accessibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->