### PR TITLE
Add GetAllFlattenedVotesWithoutFilters method to SubsquidService and …

### DIFF
--- a/src/app/api/_api-services/onchain_db_service/index.ts
+++ b/src/app/api/_api-services/onchain_db_service/index.ts
@@ -377,6 +377,10 @@ export class OnChainDbService {
 		return SubsquidService.GetVotesForAddresses({ network, voters, page, limit, proposalStatuses });
 	}
 
+	static async GetAllFlattenedVotesWithoutFilters({ network, page, limit }: { network: ENetwork; page: number; limit: number }) {
+		return SubsquidService.GetAllFlattenedVotesWithoutFilters({ network, page, limit });
+	}
+
 	// Gov Analytics Methods
 	static async GetTurnoutData({ network }: { network: ENetwork }): Promise<IRawTurnoutData> {
 		return SubsquidService.GetTurnoutData({ network });

--- a/src/app/api/_api-services/onchain_db_service/subsquid_service/subsquidQueries.ts
+++ b/src/app/api/_api-services/onchain_db_service/subsquid_service/subsquidQueries.ts
@@ -1286,6 +1286,56 @@ export class SubsquidQueries {
 
 	`;
 
+	protected static GET_ALL_FLATTENED_VOTES_WITHOUT_FILTERS = `
+		query GetAllFlattenedVotesWithoutFilters(
+			$limit: Int!,
+			$offset: Int!
+		) {
+			votes: flattenedConvictionVotes(
+				where: {
+					removedAtBlock_isNull: true
+				},
+				limit: $limit,
+				offset: $offset,
+				orderBy: createdAt_DESC
+			) {
+				proposalIndex
+				isDelegated
+				parentVote {
+					extrinsicIndex
+				}
+				type
+				voter
+				balance {
+					__typename
+					... on StandardVoteBalance {
+						value
+					}
+					... on SplitVoteBalance {
+						aye
+						nay
+						abstain
+					}
+				}
+				decision
+				createdAt
+				lockPeriod
+				proposal {
+					status
+				}
+			}
+			totalCount: flattenedConvictionVotesConnection(
+				where: {
+					removedAtBlock_isNull: true
+				},
+				orderBy: createdAt_DESC
+			) {
+				totalCount
+			}
+		}
+
+	`;
+
 	protected static GET_GOV_ANALYTICS_STATS = `
 		query GetGovAnalyticsStats {
 			totalProposals: proposalsConnection(

--- a/src/app/api/v2/votes/all/route.ts
+++ b/src/app/api/v2/votes/all/route.ts
@@ -1,0 +1,38 @@
+// Copyright 2019-2025 @polkassembly/polkassembly authors & contributors
+// This software may be modified and distributed under the terms
+// of the Apache-2.0 license. See the LICENSE file for details.
+
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+import { DEFAULT_LISTING_LIMIT, MAX_LISTING_LIMIT } from '@/_shared/_constants/listingLimit';
+import { OnChainDbService } from '@/app/api/_api-services/onchain_db_service';
+import { withErrorHandling } from '@/app/api/_api-utils/withErrorHandling';
+import { getNetworkFromHeaders } from '@/app/api/_api-utils/getNetworkFromHeaders';
+import { EProposalType } from '@/_shared/types';
+import { fetchPostData } from '@/app/api/_api-utils/fetchPostData';
+
+export const GET = withErrorHandling(async (req: NextRequest) => {
+	const network = await getNetworkFromHeaders();
+	const queryParamsSchema = z.object({
+		page: z.coerce.number().optional().default(1),
+		limit: z.coerce.number().max(MAX_LISTING_LIMIT).optional().default(DEFAULT_LISTING_LIMIT)
+	});
+
+	const { page, limit } = queryParamsSchema.parse(Object.fromEntries(req.nextUrl.searchParams));
+
+	const allVotesResult = await OnChainDbService.GetAllFlattenedVotesWithoutFilters({ network, page, limit });
+
+	const votesPromises = allVotesResult.items.map(async (vote) => {
+		const postData = await fetchPostData({ network, indexOrHash: vote.proposalIndex.toString(), proposalType: vote.proposalType as EProposalType });
+		return {
+			...vote,
+			postDetails: postData
+		};
+	});
+	const votes = await Promise.all(votesPromises);
+
+	return NextResponse.json({
+		items: votes,
+		totalCount: allVotesResult.totalCount
+	});
+});


### PR DESCRIPTION
…corresponding GraphQL query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added API endpoint GET /api/v2/votes/all to fetch all on-chain votes without filters.
  - Supports pagination via page and limit; response includes items and totalCount.
  - Network can be selected via request headers.
  - Each vote is enriched with related proposal details and key fields: proposalIndex, proposalType, decision, voterAddress, balance, createdAt, lockPeriod, extrinsicIndex, isDelegated, and status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->